### PR TITLE
NMS-13157: Escape the backslash since it is the escape character itself

### DIFF
--- a/plugin/src/main/java/org/opennms/timeseries/cortex/CortexTSS.java
+++ b/plugin/src/main/java/org/opennms/timeseries/cortex/CortexTSS.java
@@ -351,7 +351,7 @@ public class CortexTSS implements TimeSeriesStorage {
         return Math.max(1L, (long) step);
     }
 
-    private String tagsToQuery(final Collection<Tag> tags) {
+    protected static String tagsToQuery(final Collection<Tag> tags) {
         StringBuilder b = new StringBuilder();
         for (Tag tag : tags) {
             String key;
@@ -361,7 +361,8 @@ public class CortexTSS implements TimeSeriesStorage {
                 value = sanitizeMetricName(tag.getValue());
             } else {
                 key = sanitizeLabelName(tag.getKey());
-                value = tag.getValue();
+                // see NMS-13157: the backslash must be escaped since it is the escape character itself
+                value = tag.getValue().replaceAll("\\\\", "\\\\\\\\");
             }
             if (b.length() > 0) {
                 b.append(", ");

--- a/plugin/src/test/java/org/opennms/timeseries/cortex/CortexTSSTest.java
+++ b/plugin/src/test/java/org/opennms/timeseries/cortex/CortexTSSTest.java
@@ -37,11 +37,15 @@ import static org.opennms.timeseries.cortex.CortexTSS.METRIC_NAME_PATTERN;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Test;
 import org.opennms.integration.api.v1.timeseries.Aggregation;
+import org.opennms.integration.api.v1.timeseries.Tag;
 import org.opennms.integration.api.v1.timeseries.TimeSeriesFetchRequest;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableMetric;
+import org.opennms.integration.api.v1.timeseries.immutables.ImmutableTag;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableTimeSeriesFetchRequest;
 
 public class CortexTSSTest {
@@ -89,4 +93,12 @@ public class CortexTSSTest {
                 .build();
     }
 
+    @Test
+    public void testTagsToQuery() {
+        final List<Tag> tags = new ArrayList<>();
+        tags.add(new ImmutableTag("resourceId", "response:Klatschmohnwiese:192.168.12.34:icmp"));
+        tags.add(new ImmutableTag("resourceId", "response:Klatschmohnwiese:2001\\:1234\\:1234\\:1234\\:1234\\:1234\\:1234\\:1234:icmp"));
+        final String query = CortexTSS.tagsToQuery(tags);
+        assertEquals("resourceId=\"response:Klatschmohnwiese:192.168.12.34:icmp\", resourceId=\"response:Klatschmohnwiese:2001\\\\:1234\\\\:1234\\\\:1234\\\\:1234\\\\:1234\\\\:1234\\\\:1234:icmp\"", query);
+    }
 }


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-13157

The issue was really tricky. The error pattern was as follows: For nodes queried directly via OpenNMS, no response graphs of IPv6 addresses appeared at all, i.e. there were no errors at all. It just seemed that they were simply not present. In the case a Minion was used the response time graphs for IPv6 interfaces were listed but the graphs gave "Query failed." error messages.

It was actually a combination of two errors. In one special case the search()-method of the TimeseriesSearcher class did only line up the path elements without escaping the colons. Furthermore, the cortex plugin did not escape the backslashes itself. This resulted to a query error sind the backslash is the escape character itself and needs to be escaped by a backslash itself.

A second PR exists for the changes in OpenNMS:
* PR: https://github.com/OpenNMS/opennms/pull/3345