### PR TITLE
NMS-13357: Lever regex for indexing of resource paths (resorceId)

### DIFF
--- a/plugin/src/main/java/org/opennms/timeseries/cortex/CortexTSS.java
+++ b/plugin/src/main/java/org/opennms/timeseries/cortex/CortexTSS.java
@@ -473,8 +473,11 @@ public class CortexTSS implements TimeSeriesStorage {
             String value;
             if (IntrinsicTagNames.name.equals(matcher.getKey())) {
                 key = METRIC_NAME_LABEL;
-                // TODO: Patrick: sanitation is deactivated since we kill otherwise the regex. We need to find a better solution for that...
-                value = matcher.getValue(); // sanitizeMetricName(tag.getValue());
+                if(TagMatcher.Type.EQUALS == matcher.getType() || TagMatcher.Type.NOT_EQUALS == matcher.getType()) {
+                    value = sanitizeMetricName(matcher.getValue());
+                } else {
+                    value = matcher.getValue();
+                }
             } else {
                 key = sanitizeLabelName(matcher.getKey());
                 // see NMS-13157: the backslash must be escaped since it is the escape character itself

--- a/plugin/src/main/java/org/opennms/timeseries/cortex/CortexTSS.java
+++ b/plugin/src/main/java/org/opennms/timeseries/cortex/CortexTSS.java
@@ -28,6 +28,8 @@
 
 package org.opennms.timeseries.cortex;
 
+import static org.opennms.timeseries.cortex.ResultMapper.externalTagToLabel;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -256,6 +258,12 @@ public class CortexTSS implements TimeSeriesStorage {
                                 .setValue(tag.getValue()));
                     }
                 });
+        // Convert external tags
+        for(Tag tag : sample.getMetric().getExternalTags()){
+            builder.addLabels(externalTagToLabel(tag));
+        }
+
+
         // Add the sample timestamp & value
         builder.addSamples(PrometheusTypes.Sample.newBuilder()
                 .setTimestamp(sample.getTime().toEpochMilli())

--- a/plugin/src/main/java/org/opennms/timeseries/cortex/ResultMapper.java
+++ b/plugin/src/main/java/org/opennms/timeseries/cortex/ResultMapper.java
@@ -64,6 +64,7 @@ public class ResultMapper {
     public static <T> Metric toMetricFromMap(Map<String, T> tags) {
         final Set<Tag> intrinsicTags = new LinkedHashSet<>();
         final Set<Tag> metaTags = new LinkedHashSet<>();
+        final Set<Tag> externalTags = new LinkedHashSet<>();
         for (Map.Entry<String, T> entry : tags.entrySet()) {
             final String labelName = entry.getKey();
             final String labelValue = entry.getValue().toString();
@@ -76,11 +77,13 @@ public class ResultMapper {
             final Tag tag = new ImmutableTag(labelName, labelValue);
             if (INTRINSIC_TAG_NAMES.contains(labelName)) {
                 intrinsicTags.add(tag);
+            } else if (labelName.startsWith("_ext")) {
+                externalTags.add(tag);
             } else {
                 metaTags.add(tag);
             }
         }
-        return new ImmutableMetric(intrinsicTags, metaTags);
+        return new ImmutableMetric(intrinsicTags, metaTags, externalTags);
     }
 
     static <T> Stream<T> iteratorToFiniteStream(final Iterator<T> iterator) {

--- a/plugin/src/main/java/org/opennms/timeseries/cortex/ResultMapper.java
+++ b/plugin/src/main/java/org/opennms/timeseries/cortex/ResultMapper.java
@@ -88,8 +88,8 @@ public class ResultMapper {
     static PrometheusTypes.Label.Builder externalTagToLabel(final Tag tag) {
         // _ext_%hash% = %key%=%value%
         // %hash% is a hash of the value - the key contains special characters we want to preserve, so we place it in the value instead
-        String name = "_ext_" + tag.getValue().hashCode();
         String value = tag.getKey() + "=" + tag.getValue();
+        String name = "_ext_" + value.hashCode();
         return PrometheusTypes.Label.newBuilder()
                 .setName(name)
                 .setValue(value);

--- a/plugin/src/main/java/org/opennms/timeseries/cortex/ResultMapper.java
+++ b/plugin/src/main/java/org/opennms/timeseries/cortex/ResultMapper.java
@@ -5,10 +5,8 @@ import static org.opennms.timeseries.cortex.CortexTSS.METRIC_NAME_LABEL;
 
 import java.time.Instant;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -23,6 +21,8 @@ import org.opennms.integration.api.v1.timeseries.Tag;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableMetric;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableSample;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableTag;
+
+import prometheus.PrometheusTypes;
 
 public class ResultMapper {
 
@@ -62,31 +62,45 @@ public class ResultMapper {
     }
 
     public static <T> Metric toMetricFromMap(Map<String, T> tags) {
-        final Set<Tag> intrinsicTags = new LinkedHashSet<>();
-        final Set<Tag> metaTags = new LinkedHashSet<>();
-        final Set<Tag> externalTags = new LinkedHashSet<>();
+        ImmutableMetric.MetricBuilder metric = ImmutableMetric.builder();
+
         for (Map.Entry<String, T> entry : tags.entrySet()) {
             final String labelName = entry.getKey();
             final String labelValue = entry.getValue().toString();
 
             if (METRIC_NAME_LABEL.equals(labelName)) {
-                intrinsicTags.add(new ImmutableTag(IntrinsicTagNames.name, labelValue));
-                continue;
-            }
-
-            final Tag tag = new ImmutableTag(labelName, labelValue);
-            if (INTRINSIC_TAG_NAMES.contains(labelName)) {
-                intrinsicTags.add(tag);
+                metric.intrinsicTag(IntrinsicTagNames.name, labelValue);
             } else if (labelName.startsWith("_ext")) {
-                externalTags.add(tag);
-            } else {
-                metaTags.add(tag);
+                metric.externalTag(externalLabelToTag(labelValue));
+            } else if (INTRINSIC_TAG_NAMES.contains(labelName)) {
+                metric.intrinsicTag(labelName, labelValue);
+            } else  {
+                metric.metaTag(labelName, labelValue);
             }
         }
-        return new ImmutableMetric(intrinsicTags, metaTags, externalTags);
+        return metric.build();
     }
 
     static <T> Stream<T> iteratorToFiniteStream(final Iterator<T> iterator) {
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false);
+    }
+
+    static PrometheusTypes.Label.Builder externalTagToLabel(final Tag tag) {
+        // _ext_%hash% = %key%=%value%
+        // %hash% is a hash of the value - the key contains special characters we want to preserve, so we place it in the value instead
+        String name = "_ext_" + tag.getValue().hashCode();
+        String value = tag.getKey() + "=" + tag.getValue();
+        return PrometheusTypes.Label.newBuilder()
+                .setName(name)
+                .setValue(value);
+    }
+
+    static Tag externalLabelToTag(final String labelValue) {
+        // _ext_%hash% = %key%=%value%
+        // %hash% is a hash of the value - the key contains special characters we want to preserve, so we place it in the value instead
+        String[] keyValue = labelValue.split("=");
+        String key = keyValue[0];
+        String value = keyValue[1];
+        return new ImmutableTag(key, value);
     }
 }

--- a/plugin/src/main/java/org/opennms/timeseries/cortex/shell/MetricQuery.java
+++ b/plugin/src/main/java/org/opennms/timeseries/cortex/shell/MetricQuery.java
@@ -41,8 +41,8 @@ import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.opennms.integration.api.v1.timeseries.Metric;
-import org.opennms.integration.api.v1.timeseries.Tag;
-import org.opennms.integration.api.v1.timeseries.immutables.ImmutableTag;
+import org.opennms.integration.api.v1.timeseries.TagMatcher;
+import org.opennms.integration.api.v1.timeseries.immutables.ImmutableTagMatcher;
 import org.opennms.timeseries.cortex.CortexTSS;
 
 @Command(scope = "opennms-cortex", name = "query-metrics", description = "Find metrics.", detailedDescription= "pairs")
@@ -57,9 +57,9 @@ public class MetricQuery implements Action {
 
     @Override
     public Object execute() throws Exception {
-        final List<Tag> tags = toTags(arguments);
+        final List<TagMatcher> tags = toTags(arguments);
         System.out.println("Querying metrics for tags: " + tags);
-        List<Metric> metrics = tss.getMetrics(tags);
+        List<Metric> metrics = tss.findMetrics(tags);
         System.out.println("Metrics:");
         for (Metric metric : metrics) {
             System.out.println("\t" + metric);
@@ -70,7 +70,7 @@ public class MetricQuery implements Action {
         return null;
     }
 
-    public static List<Tag> toTags(final Collection<String> s) {
+    public static List<TagMatcher> toTags(final Collection<String> s) {
         if (s.size() % 2 == 1) {
             throw new IllegalArgumentException("collection must have an even number of arguments");
         }
@@ -79,7 +79,7 @@ public class MetricQuery implements Action {
                 Collectors.groupingBy(el -> {
                     final int i = counter.getAndIncrement();
                     return (i % 2 == 0) ? i : i - 1;
-                })).values().stream().map(a -> new ImmutableTag(a.get(0), (a.size() == 2 ? a.get(1) : null)))
+                })).values().stream().map(a -> ImmutableTagMatcher.builder().key(a.get(0)).value((a.size() == 2 ? a.get(1) : null)).build())
                 .collect(Collectors.toList());
     }
 }

--- a/plugin/src/test/java/org/opennms/timeseries/cortex/CortexTSSIntegrationTest.java
+++ b/plugin/src/test/java/org/opennms/timeseries/cortex/CortexTSSIntegrationTest.java
@@ -144,6 +144,22 @@ public class CortexTSSIntegrationTest extends AbstractStorageIntegrationTest {
                 timeOfLastSample, expectedEarliestTimeOfLastSample),timeOfLastSample.isAfter(expectedEarliestTimeOfLastSample));
     }
 
+    @Test
+    @Ignore
+    public void shouldFindWithNotEquals() throws Exception {
+        // Cortex doesn't seem to work with negative comparison even though the documentation says so.
+        // Maybe we query wrong?
+        // Example: http://localhost:9009/prometheus/api/v1/series?match[]={resourceId!="snmp:1:opennms-jvm:org_opennms_newts_name_ring_buffer_max_size_unit=unknown"}
+    }
+
+    @Test
+    @Ignore
+    public void shouldFindOneMetricWithRegexNotMatching() throws Exception {
+        // Cortex doesn't seem to work with negative comparison even though the documentation says so.
+        // Maybe we query wrong?
+        // Example: http://localhost:9009/prometheus/api/v1/series?match[]={resourceId!~"snmp:1:opennms-jvm:org_opennms_newts_name_ring_buffer_max_size_unit=unknown"}
+    }
+
     @Override
     @Ignore // not yet implemented
     public void shouldDeleteMetrics() { }

--- a/plugin/src/test/java/org/opennms/timeseries/cortex/ResultMapperTest.java
+++ b/plugin/src/test/java/org/opennms/timeseries/cortex/ResultMapperTest.java
@@ -32,6 +32,7 @@ public class ResultMapperTest {
                 .metaTag("_idx2", "(snmp:1:opennms-jvm,4)")
                 .metaTag("_idx2w", "(snmp:1,*)")
                 .metaTag("_idx3", "(snmp:1:opennms-jvm:OpenNMS_Name_Notifd,4)")
+                .externalTag("key", "value")
                 .metaTag("host", "myHost1")
                 .metaTag("mtype", "counter")
                 .build();

--- a/plugin/src/test/resources/org/opennms/timeseries/cortex/rangeQueryResult.json
+++ b/plugin/src/test/resources/org/opennms/timeseries/cortex/rangeQueryResult.json
@@ -11,6 +11,7 @@
           "_idx2": "(snmp:1:opennms-jvm,4)",
           "_idx2w": "(snmp:1,*)",
           "_idx3": "(snmp:1:opennms-jvm:OpenNMS_Name_Notifd,4)",
+          "_ext_123": "key=value",
           "host": "myHost1",
           "mtype": "counter",
           "resourceId": "snmp:1:opennms-jvm:org_opennms_newts_name_ring_buffer_max_size_unit=unknown"

--- a/plugin/src/test/resources/org/opennms/timeseries/cortex/seriesQueryResult.json
+++ b/plugin/src/test/resources/org/opennms/timeseries/cortex/seriesQueryResult.json
@@ -8,6 +8,7 @@
       "_idx2": "(snmp:1:opennms-jvm,4)",
       "_idx2w": "(snmp:1,*)",
       "_idx3": "(snmp:1:opennms-jvm:OpenNMS_Name_Notifd,4)",
+      "_ext_123": "key=value",
       "host": "myHost1",
       "mtype": "counter",
       "resourceId": "snmp:1:opennms-jvm:org_opennms_newts_name_ring_buffer_max_size_unit=unknown"

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <okio.bundle.version>1.14.0_1</okio.bundle.version>
         <okhttp.version>3.10.0</okhttp.version>
         <okhttp.bundle.version>3.10.0_2</okhttp.bundle.version>
-        <opennms.api.version>0.5.2-SNAPSHOT</opennms.api.version>
+        <opennms.api.version>0.6.0-SNAPSHOT</opennms.api.version>
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <protoc.version>3.12.0</protoc.version>


### PR DESCRIPTION
Works only if build locally with:
https://github.com/OpenNMS/opennms-integration-api/tree/ps/NMS-13356-ts-2.0
https://github.com/OpenNMS/opennms/tree/NMS-13357-tag-regex

Jira: https://issues.opennms.org/browse/NMS-13357