### PR TITLE
NMS-14456: Missed renaming exteralTagsCacheSize in blueprint

### DIFF
--- a/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,7 @@
             <cm:property name="writeTimeoutInMs" value="1000" />
             <cm:property name="readTimeoutInMs" value="1000" />
             <cm:property name="metricCacheSize" value="1000" />
-            <cm:property name="externalTagsCache" value="1000" />
+            <cm:property name="externalTagsCacheSize" value="1000" />
             <cm:property name="bulkheadMaxWaitDuration" value="9223372036854775807" />
             <cm:property name="organizationId" value="" />
         </cm:default-properties>
@@ -27,7 +27,7 @@
         <argument value="${writeTimeoutInMs}" />
         <argument value="${readTimeoutInMs}" />
         <argument value="${metricCacheSize}" />
-        <argument value="${externalCacheSize}" />
+        <argument value="${externalTagsCacheSize}" />
         <argument value="${bulkheadMaxWaitDuration}" />
         <argument value="${organizationId}" />
     </bean>


### PR DESCRIPTION
Missed renaming property in blueprint after renaming exteralTagsCacheSize