### PR TITLE
Make KeyValueStore non-optional to avoid intermittent failure on load

### DIFF
--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -13,6 +13,9 @@
         <bundle dependency="true">mvn:org.json/json/${json.version}</bundle>
         <bundle dependency="true">mvn:org.opennms.plugin.timeseries.cortex.wrap/resilience4j/${project.version}</bundle>
         <bundle>mvn:org.opennms.plugins.timeseries/cortex-plugin/${project.version}</bundle>
+        <capability>
+          osgi.service;objectClass=org.opennms.integration.api.v1.distributed.KeyValueStore;effective:=active
+        </capability>
     </feature>
 
     <feature name="tss-cortex-okhttp" description="okhttp" version="${okhttp.version}">

--- a/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,7 +33,7 @@
     </bean>
 
     <!--Key-value store -->
-    <reference id="keyValueStore" interface="org.opennms.integration.api.v1.distributed.KeyValueStore" availability="optional"/>
+    <reference id="keyValueStore" interface="org.opennms.integration.api.v1.distributed.KeyValueStore"/>
 
     <bean id="timeSeriesStorage" class="org.opennms.timeseries.cortex.CortexTSS" destroy-method="destroy">
         <argument ref="cortexTssConfig" />


### PR DESCRIPTION
We've seen multiple instances at one installation where this is happening
intermittently on startup:

...
Caused by: org.osgi.service.blueprint.container.ServiceUnavailableException: No matching service for optional OSGi service reference: (objectClass=org.opennms.integration.api.v1.distributed.KeyValueStore)
        at org.apache.aries.blueprint.container.ReferenceRecipe.getService(ReferenceRecipe.java:272) ~[?:?]
        at org.apache.aries.blueprint.container.ReferenceRecipe.access$000(ReferenceRecipe.java:57) ~[?:?]
        at org.apache.aries.blueprint.container.ReferenceRecipe$ServiceDispatcher.call(ReferenceRecipe.java:341) ~[?:?]
        at Proxy2eb34fe8_fa63_41d0_96b1_a2e6f7cd7d24.enumerateContextAsync(Unknown Source) ~[?:?]
        at org.opennms.timeseries.cortex.CortexTSS.<init>(CortexTSS.java:180) ~[?:?]
...
