### PR TITLE
ci: restrict deploy to the trunk and release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,11 +82,15 @@ workflows:
             - "gpg-signing"
           requires:
             - tests
-          # filters:
-          #   tags:
-          #     only: /^v.*/
-          #   branches:
-          #     ignore: /.*/
+          # Snapshots publish from the trunk; releases publish from vX.Y.Z tags.
+          # Feature branches must not deploy — they share the trunk's -SNAPSHOT
+          # version and would overwrite it in OSSRH.
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only:
+                - main
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,15 +82,18 @@ workflows:
             - "gpg-signing"
           requires:
             - tests
-          # Snapshots publish from the trunk; releases publish from vX.Y.Z tags.
-          # Feature branches must not deploy — they share the trunk's -SNAPSHOT
-          # version and would overwrite it in OSSRH.
+          # Snapshots publish from the trunk and from maintenance branches; releases
+          # publish from vX.Y.Z tags. Feature branches must not deploy — they share
+          # the trunk's -SNAPSHOT version and would overwrite it in OSSRH.
+          # The job itself refuses to publish a non-SNAPSHOT version from a branch
+          # build; see the guard in the deploy job.
           filters:
             tags:
               only: /^v.*/
             branches:
               only:
                 - main
+                - /^release-.*/
 
 jobs:
   build:
@@ -155,7 +158,21 @@ jobs:
             - v1-dependencies-{{ checksum "pom.xml" }}
 
       - run:
-          name: Upload snapshot
+          name: Publish to Central Portal
           command: |
+            VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+            echo "Project version: ${VERSION}${CIRCLE_TAG:+ (tag ${CIRCLE_TAG})}"
+
+            # RELEASING.md sets the release version on main in its own PR, so between
+            # that merge and the vX.Y.Z tag the trunk carries a non-SNAPSHOT version.
+            # central-publishing-maven-plugin runs with autoPublish=true, so deploying
+            # here would push a real, untagged release to Maven Central - and because
+            # released coordinates are immutable, the later tag build would then fail
+            # on the same GAV. Releases come from tags only.
+            if [ -z "${CIRCLE_TAG}" ] && [ "${VERSION%-SNAPSHOT}" = "${VERSION}" ]; then
+              echo "Refusing to publish release ${VERSION} from a branch build. Push a vX.Y.Z tag instead."
+              exit 0
+            fi
+
             mvn -s .circleci/.circleci.settings.xml -Prelease -DskipTests=true -Dmaven.verify.skip=true -Dmaven.install.skip=true deploy
 


### PR DESCRIPTION
## Problem

The `deploy` job's filters were commented out in 39837d3 ("disable filtering on deploy"), so `deploy` runs after `tests` on **every branch build**.

This is not theoretical — it happened four times today while rebasing the Dependabot queue. These CircleCI jobs each published `2.1.1-SNAPSHOT` to OSSRH from a Dependabot feature branch:

| Job | Branch |
| --- | --- |
| [1041](https://circleci.com/gh/OpenNMS-Plugins/opennms-prometheus-remotewrite-plugin/1041) | `...maven-bundle-plugin-6.0.2` (#111) |
| [1044](https://circleci.com/gh/OpenNMS-Plugins/opennms-prometheus-remotewrite-plugin/1044) | `...protobuf-java-3.25.5` (#90) |
| [1047](https://circleci.com/gh/OpenNMS-Plugins/opennms-prometheus-remotewrite-plugin/1047) | `...log4j-core-2.25.4` (#114) |
| [1050](https://circleci.com/gh/OpenNMS-Plugins/opennms-prometheus-remotewrite-plugin/1050) | `...guava-33.6.0-jre` (#112) |

Because every branch carries the same `-SNAPSHOT` version, any branch build overwrites the trunk's snapshot in OSSRH. Today that is noise. It becomes a correctness problem the moment a release version is set on a branch, because that branch would publish a **real release to Maven Central** without a tag.

## Change

```yaml
- deploy:
    requires:
      - tests
    filters:
      tags:
        only: /^v.*/
      branches:
        only:
          - main
```

Effective filters after this change:

```
build  -> tags: only /^v.*/
tests  -> tags: only /^v.*/
merge  -> branches: only [/^release-.*/]
deploy -> tags: only /^v.*/, branches: only [main]
```

## Why not just uncomment the original block

The commented-out block paired `tags: only /^v.*/` with `branches: ignore: /.*/`, which would have stopped snapshot publishing from the trunk altogether. That is plausibly why it was disabled in the first place.

Allowing `main` **plus** `v*` tags keeps continuous snapshots from the trunk, gates releases behind a signed tag, and stops feature branches from deploying at all.

## Note for the maintainer

This reverses a deliberate commit (39837d3), so it wants your sign-off rather than a rubber stamp. If continuous snapshot publishing from the trunk is *not* wanted, the alternative is `branches: ignore: /.*/` — tags only — and I am happy to switch it.

The dead `merge` job is intentionally left alone: its `from: release-2.x` no longer exists, but the inline comment says it is being kept on purpose.

## Verification

`.circleci/config.yml` parses, and the resolved per-job filters are as listed above. CircleCI's own validation on this PR is the real check.
